### PR TITLE
Refactor hasStraight() method

### DIFF
--- a/src/main/java/com/skraylabs/poker/ProbabilityCalculator.java
+++ b/src/main/java/com/skraylabs/poker/ProbabilityCalculator.java
@@ -26,6 +26,7 @@ import java.util.stream.IntStream;
 class ProbabilityCalculator {
 
   private static final int DECK_SIZE = 52;
+  private static final int STRAIGHT_SIZE = 5;
 
   private GameState gameState;
 
@@ -395,7 +396,7 @@ class ProbabilityCalculator {
    */
   static boolean hasStraight(Collection<Card> cards) {
     boolean result = false;
-    if (cards.size() >= 5) {
+    if (cards.size() >= STRAIGHT_SIZE) {
       // Check for Straights with Aces Low
       result = hasStraight(cards, rank -> rank.aceLowValue());
 
@@ -419,7 +420,7 @@ class ProbabilityCalculator {
    */
   private static boolean hasStraight(Collection<Card> cards, Function<Rank, Integer> rankFunction) {
     boolean result = false;
-    if (cards.size() >= 5) {
+    if (cards.size() >= STRAIGHT_SIZE) {
       // Sort cards by Rank, according to rankFunction
       ArrayList<Card> sortedCards = new ArrayList<>(cards);
       Comparator<Card> rankComparator = (card1, card2) ->
@@ -440,7 +441,7 @@ class ProbabilityCalculator {
           if (rankValueDelta == 1) {
             // Advance the sequence
             cardSequence.add(card);
-            if (cardSequence.size() == 5) {
+            if (cardSequence.size() == STRAIGHT_SIZE) {
               result = true;
               break;
             }

--- a/src/main/java/com/skraylabs/poker/ProbabilityCalculator.java
+++ b/src/main/java/com/skraylabs/poker/ProbabilityCalculator.java
@@ -435,28 +435,44 @@ class ProbabilityCalculator {
           cardSequence.add(card);
         } else {
           Card previousCard = cardSequence.get(cardSequence.size() - 1);
-          int cardRankValue = rankFunction.apply(card.getRank());
-          int previousCardRankValue = rankFunction.apply(previousCard.getRank());
-          int rankValueDelta = Math.abs(cardRankValue - previousCardRankValue);
-          if (rankValueDelta == 1) {
+          if (cardRanksAreAdjacent(card, previousCard, rankFunction)) {
             // Advance the sequence
             cardSequence.add(card);
             if (cardSequence.size() == STRAIGHT_SIZE) {
               result = true;
               break;
             }
-          } else if (rankValueDelta > 1) {
+          } else if (card.getRank() != previousCard.getRank()) {
             // Restart the sequence
             cardSequence.clear();
             cardSequence.add(card);
-          } else if (rankValueDelta == 0) {
-            // Do nothing, the sequence already has one of this Rank
+          } else if (card.getRank() == previousCard.getRank()) {
+            // Do nothing
+            // Sequence is neither advanced nor restarted
           }
         }
       }
     }
 
     return result;
+  }
+
+  /**
+   * Helper method that returns true if two Cards have "adjacent" ranks, where rank ordering is
+   * determined by a given {@code Function<Rank, Integer>}. For example, a Jack is adjacent to a
+   * Ten, but not to a King.
+   *
+   * @param card1 card to compare
+   * @param card2 card to compare
+   * @param rankFunction determines order of {@link Rank} values
+   * @return {@code true} if {@code card1} and {@code card2} are adjacent in rank; {@code false} if
+   *         they have equivalent ranks or are non-neighboring ranks
+   */
+  private static boolean cardRanksAreAdjacent(Card card1, Card card2,
+      Function<Rank, Integer> rankFunction) {
+    int rank1 = rankFunction.apply(card1.getRank());
+    int rank2 = rankFunction.apply(card2.getRank());
+    return Math.abs(rank1 - rank2) == 1;
   }
 
   /**

--- a/src/test/java/com/skraylabs/poker/StraightTest.java
+++ b/src/test/java/com/skraylabs/poker/StraightTest.java
@@ -51,6 +51,20 @@ public class StraightTest {
   }
 
   @Test
+  public void givenNotAStraightWithDuplicateRanksReturnsFalse() {
+    ArrayList<Card> cards = new ArrayList<>();
+    cards.add(new Card(Rank.ACE, Suit.CLUBS));
+    cards.add(new Card(Rank.TWO, Suit.CLUBS));
+    cards.add(new Card(Rank.THREE, Suit.CLUBS));
+    cards.add(new Card(Rank.FOUR, Suit.CLUBS));
+    cards.add(new Card(Rank.FOUR, Suit.SPADES));
+
+    boolean result = ProbabilityCalculator.hasStraight(cards);
+
+    assertThat(result, is(false));
+  }
+
+  @Test
   public void givenAStraightReturnsTrue() {
     ArrayList<Card> cards = new ArrayList<>();
     cards.add(new Card(Rank.ACE, Suit.CLUBS));


### PR DESCRIPTION
This is an attempt to make `ProbabilityCalculator.hasStraight()` more readable.

My line-of-thinking took a pivot between the first three commits and the fourth commit:
- **first three commits**: check for straights with aces low and then separately for aces high, if needed; abstract out helper methods as needed
- **fourth commit**: instead of doing checking for straights in two different orderings, just place Aces on both ends of a sorted list!

Overall, I think the method is more readable, but could probably stand to have more private methods abstracted out of it.  Good enough for now; may revisit this _after_ I have broken up `ProbabilityCalculator` into smaller classes (a future pull request).
