### PR TITLE
Use Collections.singleton() to simplify.

### DIFF
--- a/src/main/java/com/skraylabs/poker/outcome/OutcomeCalculator.java
+++ b/src/main/java/com/skraylabs/poker/outcome/OutcomeCalculator.java
@@ -8,6 +8,7 @@ import com.skraylabs.poker.model.Pocket;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -71,9 +72,7 @@ public class OutcomeCalculator {
    * @return the probability of getting the specified poker outcome
    */
   double outcomeForAPlayer(Outcome outcome, int playerIndex) {
-    Collection<Outcome> outcomes = new ArrayList<>();
-    outcomes.add(outcome);
-    Map<Outcome, Double> results = outcomesForAPlayer(outcomes, playerIndex);
+    Map<Outcome, Double> results = outcomesForAPlayer(Collections.singleton(outcome), playerIndex);
     return results.get(outcome);
   }
 


### PR DESCRIPTION
In `OutcomeCalculator`, `outcomeForAPlayer()` is just a pass-through to `outcomesForAPlayer()`, but
it must first wrap its single argument in a `Collection` before invoking `outcomesForAPlayer()`.

This change just takes advantage of `Collections.singleton()` for creating a one-element `Collection`.
