### PR TITLE
Clean up map traversal

### DIFF
--- a/src/main/java/com/skraylabs/poker/outcome/OutcomeCalculator.java
+++ b/src/main/java/com/skraylabs/poker/outcome/OutcomeCalculator.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -55,10 +56,10 @@ public class OutcomeCalculator {
     Pocket pocket = gameState.getPockets()[playerIndex];
     Map<Outcome, WinLossCounter> counts = countOutcomes(outcomes, CardUtils.collectCards(board),
         CardUtils.collectCards(pocket), deck);
-    for (Outcome outcome : counts.keySet()) {
-      WinLossCounter count = counts.get(outcome);
+    for (Entry<Outcome, WinLossCounter> entry : counts.entrySet()) {
+      WinLossCounter count = entry.getValue();
       double probability = ((double) count.getWins()) / count.getCountTotal();
-      result.put(outcome, probability);
+      result.put(entry.getKey(), probability);
     }
 
     return result;

--- a/src/main/java/com/skraylabs/poker/outcome/OutcomeCalculator.java
+++ b/src/main/java/com/skraylabs/poker/outcome/OutcomeCalculator.java
@@ -114,8 +114,8 @@ public class OutcomeCalculator {
         nextUndealtCards.removeAll(dealtCards);
         Map<Outcome, WinLossCounter> nextCounts =
             countOutcomes(outcomes, nextBoard, pocket, nextUndealtCards);
-        for (Outcome outcome : result.keySet()) {
-          result.get(outcome).incrementBy(nextCounts.get(outcome));
+        for (Map.Entry<Outcome, WinLossCounter> entry : result.entrySet()) {
+          entry.getValue().incrementBy(nextCounts.get(entry.getKey()));
         }
       }
     }

--- a/src/main/java/com/skraylabs/poker/outcome/OutcomeCalculator.java
+++ b/src/main/java/com/skraylabs/poker/outcome/OutcomeCalculator.java
@@ -9,9 +9,7 @@ import com.skraylabs.poker.model.Pocket;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -47,7 +45,6 @@ public class OutcomeCalculator {
           .format("Parameter \"playerIndex\" must be in range [0, %d].", GameState.MAX_PLAYERS));
     }
 
-    Map<Outcome, Double> result = new HashMap<>();
     Collection<Card> dealtCards = CardUtils.collectCards(gameState);
     Collection<Card> deck = makeDeckOfUndealtCards(dealtCards);
 
@@ -56,12 +53,9 @@ public class OutcomeCalculator {
     Pocket pocket = gameState.getPockets()[playerIndex];
     Map<Outcome, WinLossCounter> counts = countOutcomes(outcomes, CardUtils.collectCards(board),
         CardUtils.collectCards(pocket), deck);
-    for (Entry<Outcome, WinLossCounter> entry : counts.entrySet()) {
-      WinLossCounter count = entry.getValue();
-      double probability = ((double) count.getWins()) / count.getCountTotal();
-      result.put(entry.getKey(), probability);
-    }
 
+    Map<Outcome, Double> result = counts.entrySet().stream().collect(
+        Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue().getWinPercentage()));
     return result;
   }
 

--- a/src/main/java/com/skraylabs/poker/outcome/OutcomeChecker.java
+++ b/src/main/java/com/skraylabs/poker/outcome/OutcomeChecker.java
@@ -248,8 +248,7 @@ public class OutcomeChecker {
 
     List<Card> result = new ArrayList<Card>();
     Map<T, List<Card>> cardsByType = cards.stream().collect(Collectors.groupingBy(typeFunction));
-    for (T key : cardsByType.keySet()) {
-      List<Card> cardsOfType = cardsByType.get(key);
+    for (List<Card> cardsOfType : cardsByType.values()) {
       if (cardsOfType.size() >= number) {
         result = cardsOfType;
       }

--- a/src/main/java/com/skraylabs/poker/outcome/WinLossCounter.java
+++ b/src/main/java/com/skraylabs/poker/outcome/WinLossCounter.java
@@ -26,6 +26,14 @@ class WinLossCounter {
     return this.wins + this.losses;
   }
 
+  public double getWinPercentage() {
+    return ((double) this.wins) / getCountTotal();
+  }
+
+  public double getLossPercentage() {
+    return ((double) this.losses) / getCountTotal();
+  }
+
   public void incrementWinsBy(int wins) {
     if (wins <= 0) {
       throw new IllegalArgumentException("Argument must be a positive integer.");


### PR DESCRIPTION
Audit code to determine better alternatives to using `Map.keySet()`.

There is nothing inherently wrong with `keySet()`, but I was using it improperly -- mostly because I was new to Java 8 streams and ignorant of `Map.entrySet()`.

`Map.entrySet()` can provide a stream of key-value pairs (a.k.a. entries), which can be really useful when you need access to both!
